### PR TITLE
Add metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ by adding `sms_factor_elixir` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:sms_factor_elixir, "~> 0.3.0"}
+    {:sms_factor_elixir, "~> 0.5.0"}
   ]
 end
 ```

--- a/lib/sms_factor/metrics.ex
+++ b/lib/sms_factor/metrics.ex
@@ -1,0 +1,30 @@
+defmodule SMSFactor.Metrics do
+  @moduledoc """
+  Wrappers around **Metrics** section of SMSFactor API.
+  """
+
+  @typedoc """
+  Params for getting consumption.
+
+  - `date_start` : Add a filter to retrieve consumption of which send date is after this date. Date format must be as follow: Y-m-d
+  - `date_end` : Add a filter to retrieve consumption of which send date is before this date. Date format must be as follow: Y-m-d
+  - `country` : Add a filter to retrieve your consumption for specific country. You can retrieve the consumption for multiple countries separated by a comma. Countries must be provided in alpha2 format. country=FR,CH
+  - `sub_account_id` : Add a filter to retrieve the consumption of a specific sub account.
+
+  ## Example
+
+  ```elixir
+  %{
+    date_start: "2021-01-01",
+    date_end: "2021-01-31",
+    country: "FR,CH",
+    sub_account_id: "1234567890"
+  }
+  ```
+  """
+  @type consumption_params() :: %{atom() => String.t()}
+
+  @spec get_consumption(Tesla.Client.t(), consumption_params()) :: Tesla.Env.result()
+  def get_consumption(client, params),
+    do: Tesla.get(client, "/metrics/consumption", query: params)
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SMSFactor.MixProject do
   def project do
     [
       app: :sms_factor,
-      version: "0.4.0",
+      version: "0.5.0",
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       description: description(),


### PR DESCRIPTION
https://dev.smsfactor.com/en/api/sms/metrics/retrieve-metrics

```elixir
iex(10)> SMSFactor.Metrics.get_consumption(client, %{date_start: "2025-10-01", date_end: "2025-10-32",  sub_account_id: "103367", country: "FR"})
{:ok,
 %{
   "data" => %{
     "by_country" => %{"FR" => 207496},
     "by_sub_accounts" => [
       %{
         "account_id" => "103367",
         "company" => nil,
         "conso" => %{"by_country" => %{"FR" => 207495}, "total" => 207495}
       }
     ],
     "my_account" => %{
       "account_id" => 44652,
       "company" => "DELIGHT (SAS ONE DRY NUGGET)",
       "conso" => %{"by_country" => %{"FR" => 1}, "total" => 1}
     },
     "total" => 207496
   },
   "message" => "OK",
   "status" => 1
 }}
```